### PR TITLE
Fix a problem on LocalNode closing.

### DIFF
--- a/elastic4s-embedded/src/main/scala/com/sksamuel/elastic4s/embedded/LocalNode.scala
+++ b/elastic4s-embedded/src/main/scala/com/sksamuel/elastic4s/embedded/LocalNode.scala
@@ -122,9 +122,13 @@ class InternalLocalNode(settings: Settings, plugins: List[Class[_ <: Plugin]])
   override def client(shutdownNodeOnClose: Boolean): ElasticClient = new ElasticClient {
     private val delegate            = ElasticClient(s"elasticsearch://$host:$port")
     override def client: HttpClient = delegate.client
-    override def close(): Unit =
+    override def close(): Unit = {
+      Try {
+        delegate.client.close()
+      }
       if (shutdownNodeOnClose)
         stop()
+    }
   }
 }
 


### PR DESCRIPTION
When the ElasticClient generated by LocalNode closed, the HttpClient will not be closed. That leads the jvm will not close automatically. This pr fix the problem this problem by close the HttpClient on ElasticClient closing.