### PR TITLE
Fix a bug in build result to object by circe.

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/get/GetResponse.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/get/GetResponse.scala
@@ -34,6 +34,6 @@ case class GetResponse(@JsonProperty("_id") id: String,
 
   def storedFieldsAsMap: Map[String, AnyRef]    = Option(fields).getOrElse(Map.empty)
   override def sourceAsMap: Map[String, AnyRef] = Option(_source).getOrElse(Map.empty)
-  override def sourceAsString: String           = SourceAsContentBuilder(_source).string()
+  override def sourceAsString: String           = SourceAsContentBuilder(Option(_source).getOrElse(Map.empty)).string()
 
 }


### PR DESCRIPTION
When use `(response: RequestSuccess[GetResponse]).result.safeTo[CommonBody]` to decode the result to case class use circe.
If the `_id` is not found. The `GetResponse._source` will be null. Then the `result.safeTo` will throw a uncatched NullPointException. Not the excepted Left[Exception].
This pr hope for fix it.